### PR TITLE
pymavlink: Correct manual_control information

### DIFF
--- a/developers/pymavlink.md
+++ b/developers/pymavlink.md
@@ -246,11 +246,14 @@ master.wait_heartbeat()
 # Send a positive x value, negative y, negative z,
 # positive rotation and no button.
 # http://mavlink.org/messages/common#MANUAL_CONTROL
+# Warning: Because of some legacy workaround, z will work between [0-1000]
+# where 0 is full reverse, 500 is no output and 1000 is full throttle.
+# x,y and r will be between [-1000 and 1000].
 master.mav.manual_control_send(
     master.target_system,
     500,
     -500,
-    -500,
+    250,
     500,
     0)
 


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>