### PR TITLE
Add install link

### DIFF
--- a/operators-manual/companion-web.md
+++ b/operators-manual/companion-web.md
@@ -1,6 +1,6 @@
 #Companion Web Interface
 
-The Companion computer hosts a useful web-interface with different pages for accessing parameters and functionalities associated with Companion. When a Companion computer is connected to a ground computer, a user can access the web-interface on [192.168.2.2:2770](http://192.168.2.2:2770). Users can access Network, System, Camera and Routing pages alongside a number of other user friendly options as described below.
+The Companion computer([Install instructions](/getting-started/installation.md#raspberry-pi)) hosts a useful web-interface with different pages for accessing parameters and functionalities associated with Companion. When a Companion computer is connected to a ground computer, a user can access the web-interface on [192.168.2.2:2770](http://192.168.2.2:2770). Users can access Network, System, Camera and Routing pages alongside a number of other user friendly options as described below.
 
 ##Companion Header
 


### PR DESCRIPTION
This adds a link in the Companion page to the install page where it can be downloaded.
I was looking for the download link and google got me to companion-web.md instead, so I figured it should be easier to get to the download link from there.