### PR TITLE
Move ArduSub issues link to main ArduPilot repo

### DIFF
--- a/resources/downloads.md
+++ b/resources/downloads.md
@@ -23,5 +23,5 @@ This is a fully configured image for the Raspberry Pi 3 computer to be used as a
 <p style="font-size:10px; text-align:center">
 Sponsored by <a href="http://www.bluerobotics.com/">Blue Robotics</a>. Code released under the <a href="https://github.com/bluerobotics/ardusub/blob/master/COPYING.txt">GPLv3 License</a>. Documentation released under the <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC-NC-SA 4.0</a>.<br />
 <a href="https://github.com/bluerobotics/ardusub-gitbook/issues/">Submit a Documentation GitHub Issue here</a> to report any errors, suggestions, or missing information in this documentation.<br />
-<a href="https://github.com/bluerobotics/ardusub/issues/">Submit an ArduSub GitHub Issue here</a> to report issues with the ArduSub software.
+<a href="https://github.com/ArduPilot/ardupilot/issues/">Submit an ArduSub GitHub Issue here</a> to report issues with the ArduSub software.
 </p>


### PR DESCRIPTION
Seems like the link should point to Ardupilot now to avoid confusion. 