### PR TITLE
pymavlink: Fix ping message to use unix time in microseconds

### DIFF
--- a/developers/pymavlink/companion_computer.py
+++ b/developers/pymavlink/companion_computer.py
@@ -17,7 +17,7 @@ def wait_conn():
     msg = None
     while not msg:
         master.mav.ping_send(
-            int(time.time()), # Unix time
+            int(time.time() * 1e6 ), # Unix time in microseconds
             0, # Ping number
             0, # Request ping of all systems
             0 # Request ping of all components

--- a/developers/pymavlink/send_rangefinder_vision.py
+++ b/developers/pymavlink/send_rangefinder_vision.py
@@ -16,7 +16,7 @@ def wait_conn():
     msg = None
     while not msg:
         master.mav.ping_send(
-            int(time.time()), # Unix time
+            int(time.time() * 1e6 ), # Unix time in microseconds
             0, # Ping number
             0, # Request ping of all systems
             0 # Request ping of all components


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>