### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 - npm install gitbook-cli -g
 - sudo pip3 install pymavlink
 - sudo pip3 install pylint
+- sudo pip3 install isort==4.3.21
 
 script:
 - gitbook install

--- a/developers/pymavlink/companion_computer.py
+++ b/developers/pymavlink/companion_computer.py
@@ -17,7 +17,7 @@ def wait_conn():
     msg = None
     while not msg:
         master.mav.ping_send(
-            int(time.time() * 1e6 ), # Unix time in microseconds
+            int(time.time() * 1e6), # Unix time in microseconds
             0, # Ping number
             0, # Request ping of all systems
             0 # Request ping of all components

--- a/developers/pymavlink/send_rangefinder_vision.py
+++ b/developers/pymavlink/send_rangefinder_vision.py
@@ -16,7 +16,7 @@ def wait_conn():
     msg = None
     while not msg:
         master.mav.ping_send(
-            int(time.time() * 1e6 ), # Unix time in microseconds
+            int(time.time() * 1e6), # Unix time in microseconds
             0, # Ping number
             0, # Request ping of all systems
             0 # Request ping of all components


### PR DESCRIPTION
Apparently it broke with pylint updating to default to isort 5.0 which doesn't support Python 3.5