### PR TITLE
Pymavlink updates

### DIFF
--- a/developers/pymavlink.md
+++ b/developers/pymavlink.md
@@ -14,18 +14,23 @@ When the autopilot is being commanded to move via RC_CHANNELS_RAW or MANUAL_CONT
 
 ## Installation
 
-#### Ubuntu 16.04
+#### Ubuntu 20.04
 
 ```sh
 # Update list of available packages
-apt update
+sudo apt update
+sudo apt -y upgrade
 
 # Install some dependencies
-apt install python python-pip python-future
+sudo apt install -y python3-pip
 
 # Install mavproxy module and everything else needed
-pip install mavproxy
+pip3 install mavproxy
 ```
+
+#### Mac/Windows
+
+With Python and pip installed, run `pip install wheel mavproxy`.
 
 ##### Test installation
 You can test your installation with python interactive shell.
@@ -62,58 +67,76 @@ There are 3 types of udp connections for `mavlink_connection`:
 * **udpin**: Binds to a specific port in address:port (server), it's necessary to receive data from clients (**udpout**) before starting to send any data.
 * **udp**: Exists for legacy reasons, works as **udpin**.
 
-##### Autopilot \(E.g: Pixhawk\) connected to the computer via serial
+### Shortcut Links
+1. [Autopilot connected to the computer via serial](#autopilot-eg-pixhawk-connected-to-the-computer-via-serial)
+1. [Run pyMavlink on the surface computer](#run-pymavlink-on-the-surface-computer)
+1. [Run pyMavlink on the companion computer](#run-pymavlink-on-the-companion-computer)
+1. [Send Message to QGroundControl](#send-message-to-qgroundcontrol)
+1. [Arm/Disarm the vehicle](#armdisarm-the-vehicle)
+1. [Change flight mode](#change-flight-mode)
+1. [Send RC \(Joystick\)](#send-rc-joystick)
+1. [Send Manual Control](#send-manual-control)
+1. [Read all parameters](#read-all-parameters)
+1. [Read and write parameters](#read-and-write-parameters)
+1. [Receive data and filter by message type](#receive-data-and-filter-by-message-type)
+1. [Request message interval](#request-message-interval)
+1. [Control Camera Gimbal](#control-camera-gimbal)
+1. [Set Servo PWM](#set-servo-pwm)
+1. [Advanced Servo/Gripper Example](#advanced-servogripper-example)
+1. [Set Target Depth/Attitude](#set-target-depthattitude)
+1. [Send GPS position](#send-gps-position)
+1. [Send rangefinder/computer vision distance measurement to the autopilot](#send-rangefindercomputer-vision-distance-measurement-to-the-autopilot)
 
+#### Autopilot \(E.g: Pixhawk\) connected to the computer via serial
 [include](pymavlink/serial_connection.py)
 
-##### Run pyMavlink on the surface computer
-
+#### Run pyMavlink on the surface computer
 [include](pymavlink/udp_connection.py)
 
-##### Run pyMavlink on the companion computer
-
+#### Run pyMavlink on the companion computer
 [include](pymavlink/companion_computer.py)
 
-##### Change flight mode
+#### Send Message to QGroundControl
+[include](pymavlink/message_qgc.py)
 
-[include](pymavlink/change_flight_mode.py)
-
-##### Arm/Disarm the vehicle
-
+#### Arm/Disarm the vehicle
 [include](pymavlink/arm_disarm.py)
 
-##### Send RC \(Joystick\)
+#### Change flight mode
+[include](pymavlink/change_flight_mode.py)
 
+#### Send RC \(Joystick\)
 [include](pymavlink/rc_joystick.py)
 
 #### Send Manual Control
-
 [include](pymavlink/manual_control.py)
 
-#### Control Camera Gimbal
-
-[include](pymavlink/camera_gimbal.py)
-
 #### Read all parameters
-
 [include](pymavlink/read_params.py)
 
 #### Read and write parameters
-
 [include](pymavlink/read_write_params.py)
 
-#### Send GPS position
-
-[include](pymavlink/send_gps.py)
-
-##### Receive data and filter by message type
-
+#### Receive data and filter by message type
 [include](pymavlink/filter_messages.py)
 
-##### Request message interval
-
+#### Request message interval
 [include](pymavlink/request_message_interval.py)
 
-##### Send rangefinder/computer vision distance measurement to the autopilot
+#### Control Camera Gimbal
+[include](pymavlink/camera_gimbal.py)
 
+#### Set Servo PWM
+[include](pymavlink/set_servo.py)
+
+#### Advanced Servo/Gripper Example
+[include](pymavlink/advanced_servo_gripper.py)
+
+#### Set Target Depth/Attitude
+[include](pymavlink/set_target_depth_attitude.py)
+
+#### Send GPS position
+[include](pymavlink/send_gps.py)
+
+#### Send rangefinder/computer vision distance measurement to the autopilot
 [include](pymavlink/send_rangefinder_vision.py)

--- a/developers/pymavlink/advanced_servo_gripper.py
+++ b/developers/pymavlink/advanced_servo_gripper.py
@@ -1,0 +1,155 @@
+"""
+Advanced example of how to control servo outputs with pymavlink.
+Includes extended example for controlling a Blue Robotics' gripper.
+
+Requires Python 3.
+
+"""
+
+# Import mavutil
+from pymavlink import mavutil
+
+class RawServoOutput:
+    """ A class for commanding a mavlink-controlled servo output port. """
+    # https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_SERVO
+    CMD_SET = mavutil.mavlink.MAV_CMD_DO_SET_SERVO
+
+    def __init__(self, master, instance, pwm_limits=(1100, 1500, 1900),
+                 set_default=True):
+        """ Initialise a RawServoOutput instance.
+
+        'master' is a mavlink connection
+        'instance' is the servo output (e.g. Pixhawk MAIN 1-8, AUX 9-16)
+        'pwm_limits' is a tuple of min, default, and max pwm pulse-widths
+            in microseconds (default (1100, 1500, 1900)).
+        'set_default' is a boolean specifying whether to command the output
+            to the specified default pulse-width (default True).
+
+        """
+        self.master     = master
+        self.instance   = instance
+        self.min_us, self._current, self.max_us = pwm_limits
+        self._diff      = self.max_us - self.min_us
+
+        if set_default:
+            self.set_direct(self._current)
+
+    def set_direct(self, us):
+        """ Directly set the PWM pulse width.
+
+        'us' is the PWM pulse width in microseconds.
+            Must be between self.min_us and self.max_us.
+
+        """
+        assert self.min_us <= us <= self.max_us, "Invalid input value."
+
+        # self.master.set_servo(self.instance, us) or:
+        self.master.mav.command_long_send(
+            self.master.target_system, self.master.target_component,
+            self.CMD_SET,
+            0, # first transmission of this command
+            self.instance, us,
+            0,0,0,0,0 # unused parameters
+        )
+        self._current = us
+
+    def set_ratio(self, proportion):
+        """ Set the PWM pulse-width ratio (auto-scale between min and max).
+
+        'proportion' is a 0-1 value, where 0 corresponds to self.min_us, and
+            1 corresponds to self.max_us.
+
+        """
+        self.set_direct(proportion * self._diff + self.min_us)
+
+    def inc(self, us=50):
+        """ Increment the PWM pulse width by 'us' microseconds. """
+        self.set_direct(max(self.max_us, self._current+us))
+
+    def dec(self, us=50):
+        """ Decrement the PWM pulse width by 'us' microseconds. """
+        self.set_direct(min(self.min_us, self._current-us))
+
+    def set_min(self):
+        """ Set the PWM to self.min_us. """
+        self.set_ratio(0)
+
+    def set_max(self):
+        """ Set the PWM to self.max_us. """
+        self.set_ratio(1)
+
+    def center(self):
+        """ Set the PWM to half-way between self.min_us and self.max_us. """
+        self.set_ratio(0.5)
+
+
+class AuxServoOutput(RawServoOutput):
+    """ A class representing a mavlink-controlled auxiliary servo output. """
+    def __init__(self, master, servo_n, main_outputs=8, **kwargs):
+        """ Initiliase a servo instance.
+
+        'master' is a mavlink connection.
+        'servo_n' is one of the auxiliary servo outputs, like the servo_n
+            outputs with QGroundControl joystick control.
+            Most likely a value between 1-3, but possibly up to 6 or 8
+            depending on setup.
+        'main_outputs' is the number of MAIN outputs are present on the
+            autopilot device (default 8).
+        **kwargs are passed to RawServoOutput.
+
+        """
+        super().__init__(master, servo_n+main_outputs, **kwargs)
+        self._main_outputs = main_outputs
+
+    @property
+    def servo_n(self):
+        """ Return the AUX servo number of this output. """
+        return self.instance - self._main_outputs
+
+
+class Gripper(AuxServoOutput):
+    """ A class representing a Blue Robotics' gripper. """
+    def __init__(self, master, servo_n, pwm_limits=(1100, 1100, 1500),
+                 **kwargs):
+        """ Initialise a Gripper instance.
+
+        'master' is a mavlink connection.
+        'servo_n' is one of the auxiliary servo outputs, like the servo_n
+            outputs with QGroundControl joystick control.
+            Most likely a value between 1-3, but possibly up to 6 or 8
+            depending on setup.
+        'pwm_limits' is a tuple of min, default, and max pwm pulse-widths
+            in microseconds (default (1100, 1100, 1900)).
+        **kwargs are passed to AuxServoOutput.
+
+        """
+        super().__init__(master, servo_n, pwm_limits=pwm_limits, **kwargs)
+
+    def open(self):
+        """ Command the gripper to open. """
+        self.set_max()
+
+    def close(self):
+        """ Command the gripper to close. """
+        self.set_min()
+
+
+# if running this file as a script:
+if __name__ == '__main__':
+    from time import sleep
+
+    # Connect to the autopilot (pixhawk) from the surface computer,
+    #  via the companion.
+    autopilot = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
+    # Wait for a heartbeat from the autopilot before sending commands
+    autopilot.wait_heartbeat()
+
+    # create a gripper instance on servo_1 (AUX output 1)
+    gripper = Gripper(autopilot, 1)
+
+    # open and close the gripper a few times
+    for _ in range(3):
+        gripper.open()
+        sleep(2)
+        gripper.close()
+        sleep(1)

--- a/developers/pymavlink/arm_disarm.py
+++ b/developers/pymavlink/arm_disarm.py
@@ -20,6 +20,11 @@ master.mav.command_long_send(
     0,
     1, 0, 0, 0, 0, 0, 0)
 
+# wait until arming confirmed (can manually check with master.motors_armed())
+print("Waiting for the vehicle to arm")
+master.motors_armed_wait()
+print('Armed!')
+
 # Disarm
 # master.arducopter_disarm() or:
 master.mav.command_long_send(
@@ -28,3 +33,6 @@ master.mav.command_long_send(
     mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
     0,
     0, 0, 0, 0, 0, 0, 0)
+
+# wait until disarming confirmed
+master.motors_disarmed_wait()

--- a/developers/pymavlink/filter_messages.py
+++ b/developers/pymavlink/filter_messages.py
@@ -1,6 +1,8 @@
 """
 Example of how to filter for specific mavlink messages coming from the
-autopilot using pymavlink
+autopilot using pymavlink.
+
+Can also filter within recv_match command - see "Read all parameters" example
 """
 # Import mavutil
 from pymavlink import mavutil

--- a/developers/pymavlink/message_qgc.py
+++ b/developers/pymavlink/message_qgc.py
@@ -1,0 +1,18 @@
+"""
+Example of sending a message to QGroundControl using pymavlink
+
+Full workflow of connecting and displaying readings from a custom sensor at:
+  https://discuss.bluerobotics.com/t/adding-a-sensor-to-mavlink-stream/7985/22
+
+"""
+
+# Import mavutil
+from pymavlink import mavutil
+
+# Create the connection to the top-side computer as companion computer/autopilot
+master = mavutil.mavlink_connection('udpout:localhost:14550', source_system=1)
+
+# Send a message for QGC to read out loud
+#  Severity from https://mavlink.io/en/messages/common.html#MAV_SEVERITY
+master.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_NOTICE,
+                           "QGC will read this".encode())

--- a/developers/pymavlink/read_params.py
+++ b/developers/pymavlink/read_params.py
@@ -13,7 +13,7 @@ from pymavlink import mavutil
 
 
 # Create the connection
-master = mavutil.mavlink_connection('udp:0.0.0.0:14550')
+master = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
 # Wait a heartbeat before sending commands
 master.wait_heartbeat()
 

--- a/developers/pymavlink/read_write_params.py
+++ b/developers/pymavlink/read_write_params.py
@@ -7,7 +7,7 @@ import time
 from pymavlink import mavutil
 
 # Create the connection
-master = mavutil.mavlink_connection('udp:0.0.0.0:14550')
+master = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
 # Wait a heartbeat before sending commands
 master.wait_heartbeat()
 

--- a/developers/pymavlink/set_servo.py
+++ b/developers/pymavlink/set_servo.py
@@ -1,0 +1,39 @@
+"""
+Example of how to directly control a Pixhawk servo output with pymavlink.
+"""
+
+import time
+# Import mavutil
+from pymavlink import mavutil
+
+def set_servo_pwm(servo_n, microseconds):
+    """ Sets AUX 'servo_n' output PWM pulse-width.
+
+    Uses https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_SERVO
+
+    'servo_n' is the AUX port to set (assumes port is configured as a servo).
+        Valid values are 1-3 in a normal BlueROV2 setup, but can go up to 8
+        depending on Pixhawk type and firmware.
+    'microseconds' is the PWM pulse-width to set the output to. Commonly
+        between 1100 and 1900 microseconds.
+
+    """
+    # master.set_servo(servo_n+8, microseconds) or:
+    master.mav.command_long_send(
+        master.target_system, master.target_component,
+        mavutil.mavlink.MAV_CMD_DO_SET_SERVO,
+        0,            # first transmission of this command
+        servo_n + 8,  # servo instance, offset by 8 MAIN outputs
+        microseconds, # PWM pulse-width
+        0,0,0,0,0     # unused parameters
+    )
+
+# Create the connection
+master = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
+# Wait a heartbeat before sending commands
+master.wait_heartbeat()
+
+# command servo_1 to go from min to max in steps of 50us, over 2 seconds
+for us in range(1100, 1900, 50):
+    set_servo_pwm(1, us)
+    time.sleep(0.125)

--- a/developers/pymavlink/set_target_depth_attitude.py
+++ b/developers/pymavlink/set_target_depth_attitude.py
@@ -1,0 +1,85 @@
+"""
+Example of how to set target depth in depth hold mode with pymavlink
+"""
+
+import time
+import math
+# Import mavutil
+from pymavlink import mavutil
+# Imports for attitude
+from pymavlink.quaternion import QuaternionBase
+
+def set_target_depth(depth):
+    """ Sets the target depth while in depth-hold mode.
+
+    Uses https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT
+
+    'depth' is technically an altitude, so set as negative meters below the surface
+        -> set_target_depth(-1.5) # sets target to 1.5m below the water surface.
+
+    """
+    master.mav.set_position_target_global_int_send(
+        int(1e3 * (time.time() - boot_time)), # ms since boot
+        master.target_system, master.target_component,
+        coordinate_frame=mavutil.mavlink.MAV_FRAME_GLOBAL_INT,
+        type_mask=0xdfe,  # ignore everything except z position
+        lat_int=0, long_int=0, alt=depth, # (x, y WGS84 frame pos - not used), z [m]
+        vx=0, vy=0, vz=0, # velocities in NED frame [m/s] (not used)
+        afx=0, afy=0, afz=0, yaw=0, yaw_rate=0
+        # accelerations in NED frame [N], yaw, yaw_rate
+        #  (all not supported yet, ignored in GCS Mavlink)
+    )
+
+def set_target_attitude(roll, pitch, yaw):
+    """ Sets the target attitude while in depth-hold mode.
+
+    'roll', 'pitch', and 'yaw' are angles in degrees.
+
+    """
+    # https://mavlink.io/en/messages/common.html#ATTITUDE_TARGET_TYPEMASK
+    # 1<<6 = THROTTLE_IGNORE -> allow throttle to be controlled by depth_hold mode
+    bitmask = 1<<6
+
+    master.mav.set_attitude_target_send(
+        int(1e3 * (time.time() - boot_time)), # ms since boot
+        master.target_system, master.target_component,
+        bitmask,
+        # -> attitude quaternion (w, x, y, z | zero-rotation is 1, 0, 0, 0)
+        QuaternionBase([math.radians(angle) for angle in (roll, pitch, yaw)]),
+        0, 0, 0, 0 # roll rate, pitch rate, yaw rate, thrust
+    )
+
+# Create the connection
+master = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
+boot_time = time.time()
+# Wait a heartbeat before sending commands
+master.wait_heartbeat()
+
+# arm ArduSub autopilot and wait until confirmed
+master.arducopter_arm()
+master.motors_armed_wait()
+
+# set the desired operating mode
+DEPTH_HOLD = 'ALT_HOLD'
+DEPTH_HOLD_MODE = master.mode_mapping()[DEPTH_HOLD]
+while not master.wait_heartbeat().custom_mode == DEPTH_HOLD_MODE:
+    master.set_mode(DEPTH_HOLD)
+
+# set a depth target
+set_target_depth(-0.5)
+
+# go for a spin
+# (set target yaw from 0 to 500 degrees in steps of 10, one update per second)
+roll_angle = pitch_angle = 0
+for yaw_angle in range(0, 500, 10):
+    set_target_attitude(roll_angle, pitch_angle, yaw_angle)
+    time.sleep(1) # wait for a second
+
+# spin the other way with 3x larger steps
+for yaw_angle in range(500, 0, -30):
+    set_target_attitude(roll_angle, pitch_angle, yaw_angle)
+    time.sleep(1)
+
+# clean up (disarm) at the end
+master.arducopter_disarm()
+master.motors_disarmed_wait()

--- a/developers/pymavlink/udp_connection.py
+++ b/developers/pymavlink/udp_connection.py
@@ -21,6 +21,9 @@ from pymavlink import mavutil
 #  E.g: --out udpbcast:192.168.2.255:yourport
 master = mavutil.mavlink_connection('udpin:0.0.0.0:14550')
 
+# Make sure the connection is valid
+master.wait_heartbeat()
+
 # Get some information !
 while True:
     try:


### PR DESCRIPTION
- [x] add hyperlinked shortcuts (ToC) to make examples easier to navigate
- [x] add sending message to QGC example (#159)
- [x] add setting target depth in depth-hold mode example (#195)
- [x] update arm-disarm example to include arming check and confirmation waits
- [ ] add input hold example (#132)
- [x] add `set_attitude_hold` in depth-hold mode example (#131)
- [x] add gripper example (#128) (possibly with `MAV_CMD_DO_SET_SERVO`)