### PR TITLE
developers: dvl: update build download link

### DIFF
--- a/.github/workflows/htmlproofer.yaml
+++ b/.github/workflows/htmlproofer.yaml
@@ -30,6 +30,6 @@ jobs:
         uses: chabad360/htmlproofer@master
         with:
           directory: "./_book"
-          # Ignore dell and te.com as they are returning error but have valid link
+          # Ignore dell, te.com, help.marinetraffic.com as they are returning error but have valid link
           # Ignore http response 0 from bluelinked.com
-          arguments: --empty-alt-ignore true --url_ignore /http:\/\/192\.168\..\*/,/http(s?):\/\/na.panasonic.com.*/,/http(s?):\/\/(www\.)?dell\.com.*/,/https:\/\/www\.te\.com\/.*/ --http-status-ignore 0
+          arguments: --empty-alt-ignore true --url_ignore /http:\/\/192\.168\..\*/,/http(s?):\/\/na.panasonic.com.*/,/http(s?):\/\/(www\.)?dell\.com.*/,/https:\/\/www\.te\.com\/.*/,/https:\/\/help\.marinetraffic\.com\/.*/ --http-status-ignore 0

--- a/developers/dvl-integration.md
+++ b/developers/dvl-integration.md
@@ -20,7 +20,7 @@ There are two ways to get the DVL support.
 
 **Option 1**
 
-Flash the [Custom build of Companion with DVL support](https://s3.amazonaws.com/downloads.bluerobotics.com/Pi/experimental/ardusubdvl.img.zip).
+Flash the [Custom build of Companion with DVL support](https://s3.amazonaws.com/downloads.bluerobotics.com/Pi/experimental/ardusubdvl-0.0.28.img.zip).
 
 **Option 2**
 

--- a/developers/dvl-integration.md
+++ b/developers/dvl-integration.md
@@ -4,7 +4,7 @@ The DVL integration with ArduSub is in a BETA stage and is currently unsupported
 
 ## Supported DVLs
 
-The [Waterlinked A50 DVL](https://waterlinked.com/product/dvl-a50/) is the only supported DVL at the moment in the beta integration.
+The [Waterlinked A50 DVL](https://store.waterlinked.com/product/dvl-a50/) is the only supported DVL at the moment in the beta integration.
 
 ### A50 DVL configuration
 

--- a/introduction/hardware-options/additional-peripheral-devices/underwater-positioning.md
+++ b/introduction/hardware-options/additional-peripheral-devices/underwater-positioning.md
@@ -30,7 +30,7 @@ SBL systems can produce better positioning accuracy in highly reflective environ
 
 ## Supported SBL Systems
 
-* [Water Linked Underwater GPS Explorer Kit](https://waterlinked.com/underwater-gps/)
+* [Water Linked Underwater GPS Explorer Kit](https://store.waterlinked.com/underwater-gps/)
 
 # USBL Positioning Systems
 

--- a/introduction/hardware-options/required-hardware/tether.md
+++ b/introduction/hardware-options/required-hardware/tether.md
@@ -20,7 +20,6 @@ Interface boards which use the [Homeplug AV](https://en.wikipedia.org/wiki/HomeP
 
 The following interface boards are supported:
 * [Blue Robotics Fathom-X Tether Interface Board Set](https://bluerobotics.com/store/comm-control-power/tether-interface/fathom-x-r1/)
-* [Blue Link Dual Ethernet Plus Serial Multiplexer (DEPS MUX)](https://blue-linked.com/online-store/ols/products/deps-mux)
 
 ## Interfaces for Fiber Optic Cable
 


### PR DESCRIPTION
- update to latest (tested working) build, on 0.0.28 with updated mavlink2rest
- download link now explicit to specific version (requires updating docs every time an updated build is made, but means it's more clear which build is in use)