### PR TITLE
reference: joystick: fix outdated depth hold description

### DIFF
--- a/reference/ardusub/joystick-setup-page.md
+++ b/reference/ardusub/joystick-setup-page.md
@@ -67,8 +67,7 @@ The roll and pitch input behaves differently in different flight modes.
 - MANUAL: The roll and pitch input control the **rotation rate** of the vehicle. As long as the joystick input is deflected, the vehicle will continue to rotate. A centered joystick input commands a rotation rate of zero.
 - ACRO: This functions like MANUAL, but the rate of rotation is precisely controlled and stabilized.
 - STABILIZE: The roll and pitch input control the **desired angle** of the vehicle attitude. When the joystick input is centered, the vehicle will stabilize a level attitude. When the joystick input is deflected, the vehicle will stabilize the deflected angle. There are two parameters that control the maximum angle of vehicle deflection: the pilot input gain (which scales the input), and the ANGLE_MAX parameter (which controls the maximum angle that the vehicle will deflect in stabilize mode). For example, if the ANGLE_MAX parameter is 80 degrees, and the input gain is 50%, when the the roll or pitch joystick input is completely deflected, the vehicle will deflect 40 degrees ( 0.5 * 80 ). Press the roll_pitch_toggle joystick button while the vehicle is deflected to lock the current deflection angle and return to controlling forward and lateral motion. To clear the roll and pitch input command, switch to MANUAL mode, or press the roll_pitch_toggle button.
-- DEPTH HOLD: This functions like STABILIZE mode, but only small angles are tolerated. The vehicle will misbehave at larger angles. Roll and pitch input should be avoided in DEPTH HOLD mode until it is [properly supported](https://github.com/ArduPilot/ardupilot/issues/9823).
-
+- DEPTH HOLD: This functions like STABILIZE mode, but the pressure-depth is also maintained. The throttle joystick is used to control the vehicle to the desired depth, and on joystick release the current depth will be stabilized to.
 
 #### Camera Control
 


### PR DESCRIPTION
Updates depth hold flight mode description, removes reference to pitch/roll control bug that was fixed in 2019.

Fixes #201 