### PR TITLE
Software components single source

### DIFF
--- a/developers/software-components.md
+++ b/developers/software-components.md
@@ -8,9 +8,7 @@ There are three major software components involved in the operation of ArduSub:
 
 Here is a typical diagram of the software components and their interactions:
 
-<iframe width="770" height="612" src="https://miro.com/app/live-embed/o9J_l8JeRj8=/?moveToViewport=-2715,-5,2902,2304&embedAutoplay=true" frameBorder="0" scrolling="no" allowFullScreen></iframe>
-
-To use the above diagram, you can scroll to zoom, click and drag to pan, and double-click to focus onto an element. Some elements have a (square) link in their top right corner, which can be clicked to go to the relevant documentation/product page. Optional components are shown as faded/translucent.
+{% include "../introduction/software-components-miro-board.md" %}
 
 <p style="font-size:10px; text-align:center">
 Sponsored by <a href="http://www.bluerobotics.com/">Blue Robotics</a>. Code released under the <a href="https://github.com/bluerobotics/ardusub/blob/master/COPYING.txt">GPLv3 License</a>. Documentation released under the <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC-NC-SA 4.0</a>.<br />

--- a/introduction/required-software.md
+++ b/introduction/required-software.md
@@ -14,6 +14,4 @@ Here is a diagram of what software piece is loaded onto which hardware component
 
 Here is a technical block diagram of the main software components and their interactions:
 
-<iframe width="770" height="612" src="https://miro.com/app/live-embed/o9J_l8JeRj8=/?moveToViewport=-2715,-5,2902,2304&embedAutoplay=true" frameBorder="0" scrolling="no" allowFullScreen></iframe>
-
-To use the above diagram, you can scroll to zoom, click and drag to pan, and double-click to focus onto an element. Some elements have a (square) link in their top right corner, which can be clicked to go to the relevant documentation/product page. Optional components are shown as faded/translucent.
+{% include "software-components-miro-board.md" %}

--- a/introduction/software-components-miro-board.md
+++ b/introduction/software-components-miro-board.md
@@ -1,0 +1,3 @@
+<iframe width="770" height="612" src="https://miro.com/app/live-embed/o9J_l8JeRj8=/?moveToViewport=-2715,-5,2902,2304&embedAutoplay=true" frameBorder="0" scrolling="no" allowFullScreen></iframe>
+
+To use the above diagram, you can scroll to zoom, click and drag to pan, and double-click to focus onto an element. Some elements have a (square) link in their top right corner, which can be clicked to go to the relevant documentation/product page. Optional components are shown as faded/translucent.


### PR DESCRIPTION
Software components diagram (Miro board) linked to from two pages. Best to have a single source so the description is shared, and any updates to the page can be performed more efficiently.