### PR TITLE
developers: pymavlink: use type_mask flags

### DIFF
--- a/developers/pymavlink/set_target_depth_attitude.py
+++ b/developers/pymavlink/set_target_depth_attitude.py
@@ -22,8 +22,20 @@ def set_target_depth(depth):
         int(1e3 * (time.time() - boot_time)), # ms since boot
         master.target_system, master.target_component,
         coordinate_frame=mavutil.mavlink.MAV_FRAME_GLOBAL_INT,
-        type_mask=0b0000_1101_1111_1011,  # ignore everything except z position
-        lat_int=0, lon_int=0, alt=depth, # (x, y WGS84 frame pos - not used), z [m]
+        type_mask=( # ignore everything except z position
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_X_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_Y_IGNORE |
+            # DON'T mavutil.mavlink.POSITION_TARGET_TYPEMASK_Z_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_VX_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_VY_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_VZ_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_AX_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_AY_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+            # DON'T mavutil.mavlink.POSITION_TARGET_TYPEMASK_FORCE_SET_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_IGNORE |
+            mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE
+        ), lat_int=0, lon_int=0, alt=depth, # (x, y WGS84 frame pos - not used), z [m]
         vx=0, vy=0, vz=0, # velocities in NED frame [m/s] (not used)
         afx=0, afy=0, afz=0, yaw=0, yaw_rate=0
         # accelerations in NED frame [N], yaw, yaw_rate


### PR DESCRIPTION
Adds clarity, and restores functionality on companion if someone wants to use it there.