### PR TITLE
developers: pymavlink: fix flag name typo

### DIFF
--- a/developers/pymavlink/set_target_depth_attitude.py
+++ b/developers/pymavlink/set_target_depth_attitude.py
@@ -32,7 +32,7 @@ def set_target_depth(depth):
             mavutil.mavlink.POSITION_TARGET_TYPEMASK_AX_IGNORE |
             mavutil.mavlink.POSITION_TARGET_TYPEMASK_AY_IGNORE |
             mavutil.mavlink.POSITION_TARGET_TYPEMASK_AZ_IGNORE |
-            # DON'T mavutil.mavlink.POSITION_TARGET_TYPEMASK_FORCE_SET_IGNORE |
+            # DON'T mavutil.mavlink.POSITION_TARGET_TYPEMASK_FORCE_SET |
             mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_IGNORE |
             mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE
         ), lat_int=0, lon_int=0, alt=depth, # (x, y WGS84 frame pos - not used), z [m]


### PR DESCRIPTION
Non-essential because it's commented out anyway, but good to be as clear as possible.