### PR TITLE
Redirect features page to ArduPilot wiki

### DIFF
--- a/.github/workflows/pagesdeploy.yaml
+++ b/.github/workflows/pagesdeploy.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt update
           sudo apt install python3-pip python3-setuptools
           sudo pip3 install pymavlink
-          sudo pip3 install pylint
+          sudo pip3 install pylint==3.3.9
           sudo pip3 install isort==4.3.21
           sudo npm install gitbook-cli -g
           # fix polyfill issue in gitbook

--- a/archive-notice.html
+++ b/archive-notice.html
@@ -1,4 +1,4 @@
-<div style="position:fixed;margin-top:-50px;background-color:rgb(252, 248, 227);color:black;padding:10px;border-radius:5px;width:100%;max-width:770px;">
+<div id="archiveNotice" style="position:fixed;margin-top:-50px;background-color:rgb(252, 248, 227);color:black;padding:10px;border-radius:5px;width:100%;max-width:770px;">
   <h2 style="margin-top:5px;margin-bottom:5px;color:black;">⚠️  ARCHIVE NOTICE ⚠️  </h2>
   <h3 style="margin-top:0px;margin-bottom:5px;color:black;">This documentation is no longer being maintained!</h3>
   <ul>
@@ -6,7 +6,8 @@
     <li>The Companion Computer Software is also archived, and has been replaced by <a href="https://blueos.cloud/">BlueOS</a>.</li>
     <li>For Control Station Software, see <a href="https://docs.qgroundcontrol.com/Stable_V4.3/en/qgc-user-guide/">QGroundControl</a> or <a href="https://blueos.cloud/cockpit/docs">Cockpit</a> (our new alternative).</li>
   </ul>
+  <div style = "display: flex; justify-content:flex-end"><button onclick="document.getElementById('archiveNotice').style.display='none';document.getElementById('noticeSpacer').style.display='none'">OK</button></div>
 </div>
-<hr style="margin-top:210px;"></hr>
+<hr id="noticeSpacer" style="margin-top:250px;"></hr>
 
 <div></div>

--- a/introduction/features.md
+++ b/introduction/features.md
@@ -1,5 +1,13 @@
 {% include "../archive-notice.html" %}
 
+<meta http-equiv="refresh" content="0; URL=https://ardupilot.org/sub/docs/introduction.html" />
+
+# This documentation has been moved to [https://ardupilot.org/sub/docs/introduction.html](https://ardupilot.org/sub/docs/introduction.html).
+
+## You should be automatically redirected.
+
+---
+
 # Features
 
 ArduSub has many features including:
@@ -13,6 +21,8 @@ ArduSub has many features including:
 - **No Programming Required**
 
 ## Supported Frames
+
+### Moved to [https://ardupilot.org/sub/docs/sub-frames.html](https://ardupilot.org/sub/docs/sub-frames.html)
 
 ArduSub includes a high-level motor library that can configure motors in any configuration. This library is used to implement a number of supported frame configurations. All configurations are shown from **top-down view**. Green thrusters indicate counter-clockwise propellers and blue thrusters indicate clockwise propellers (or vice-versa). Currently supported are:
 


### PR DESCRIPTION
1. Fixes broken CI
    - Latest pylint is crashing because of a dependency issue, and it doesn't seem worth investigating, so tying to the last version before breaking changes
1. Redirects to the new overview/features content that is being added to the ArduPilot wiki
    - Merge after ArduPilot/ardupilot_wiki#7613
    - Skips redirecting the home page for now, because some of the hard to find content would become much harder if we took away the homepage.
2. As a side-effect, the archive banner was annoying me, so I added an "OK" button to close it
    - Not persistent, but at least makes the pages readable, especially on small screen sizes